### PR TITLE
feat: Albums/<Artist>/<Album Title> folders; files as 'NN - Title.ext…

### DIFF
--- a/deezer_downloader/web/music_backend.py
+++ b/deezer_downloader/web/music_backend.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile, ZIP_DEFLATED
 from deezer_downloader.configuration import config
 from deezer_downloader.youtubedl import youtubedl_download
 from deezer_downloader.spotify import get_songs_from_spotify_website
-from deezer_downloader.deezer import TYPE_TRACK, TYPE_ALBUM, TYPE_PLAYLIST, get_song_infos_from_deezer_website, download_song, download_lrc, parse_deezer_playlist, deezer_search, get_deezer_favorites
+from deezer_downloader.deezer import TYPE_TRACK, TYPE_ALBUM, TYPE_PLAYLIST, get_song_infos_from_deezer_website, download_song, download_lrc, parse_deezer_playlist, deezer_search, get_deezer_favorites, get_album_data
 from deezer_downloader.deezer import Deezer403Exception, Deezer404Exception
 from deezer_downloader.deezer import get_file_extension
 
@@ -23,6 +23,9 @@ def check_download_dirs_exist():
 
 
 check_download_dirs_exist()
+
+# Cache album artist lookups to avoid repeated network calls per album
+_ALBUM_ARTIST_CACHE = {}
 
 
 def make_song_paths_relative_to_mpd_root(songs, prefix=""):
@@ -96,11 +99,28 @@ def download_song_and_get_absolute_filename(search_type, song, playlist_name=Non
         song_filename = "{}.{}".format(song['SNG_TITLE'], file_extension)
     song_filename = clean_filename(song_filename)
 
+    forced_album_artist = None
     if search_type == TYPE_TRACK:
         absolute_filename = os.path.join(config["download_dirs"]["songs"], song_filename)
     elif search_type == TYPE_ALBUM:
         # Build nested path: Albums/<Artist>/<Album Title>
-        artist_dir_name = clean_filename(song.get('ART_NAME', 'Unknown Artist'))
+        # Always use the album's primary artist, not the track artist (feats, guests)
+        album_id = song.get('ALB_ID')
+        artist_name = song.get('ART_NAME', 'Unknown Artist')
+        if album_id:
+            cached = _ALBUM_ARTIST_CACHE.get(album_id)
+            if cached:
+                artist_name = cached
+            else:
+                try:
+                    album_info = get_album_data(album_id)
+                    if album_info and album_info.get('ART_NAME'):
+                        artist_name = album_info['ART_NAME']
+                        _ALBUM_ARTIST_CACHE[album_id] = artist_name
+                except Exception as _:
+                    pass
+        forced_album_artist = artist_name
+        artist_dir_name = clean_filename(artist_name)
         album_dir_name = clean_filename(song.get('ALB_TITLE', 'Unknown Album'))
         album_dir = os.path.join(config["download_dirs"]["albums"], artist_dir_name, album_dir_name)
         os.makedirs(album_dir, exist_ok=True)
@@ -124,7 +144,13 @@ def download_song_and_get_absolute_filename(search_type, song, playlist_name=Non
             download_lrc(song['SNG_ID'], lrc_filename)
     else:
         print("Downloading '{}'".format(song_filename))
-        download_song(song, absolute_filename)
+        if forced_album_artist:
+            # Ensure artist metadata is the album artist for album tracks
+            song_for_download = dict(song)
+            song_for_download['ART_NAME'] = forced_album_artist
+            download_song(song_for_download, absolute_filename)
+        else:
+            download_song(song, absolute_filename)
     return absolute_filename
 
 

--- a/deezer_downloader/web/music_backend.py
+++ b/deezer_downloader/web/music_backend.py
@@ -69,36 +69,41 @@ def update_mpd_db(songs, add_to_playlist):
 def clean_filename(path):
     path = path.replace("\t", " ")
     if any(platform.win32_ver()):
-        path.replace("\"", "'")
-        array_of_special_characters = ['<', '>', ':', '"', '/', '\\', '|', '?', '*']
+        # Replace quotes on Windows to avoid issues with file systems and shells
+        path = path.replace('"', "'")
+        invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*']
     else:
-        array_of_special_characters = ['/', ':', '"', '?']
+        invalid_chars = ['/', ':', '"', '?']
 
-    return ''.join([c for c in path if c not in array_of_special_characters])
+    return ''.join([c for c in path if c not in invalid_chars])
 
 
 def download_song_and_get_absolute_filename(search_type, song, playlist_name=None):
 
     file_extension = get_file_extension()
-    if search_type == TYPE_ALBUM:
-        song_filename = "{:02d} - {} {}.{}".format(int(song['TRACK_NUMBER']),
-                                                   song['ART_NAME'],
-                                                   song['SNG_TITLE'],
-                                                   file_extension)
+    # Build filename without artist. Prefer: "trackNumber - title.ext". If track number
+    # is missing or invalid, fall back to just "title.ext".
+    track_num = None
+    try:
+        if 'TRACK_NUMBER' in song and str(song['TRACK_NUMBER']).strip() != "":
+            track_num = int(song['TRACK_NUMBER'])
+    except Exception:
+        track_num = None
+
+    if track_num is not None and track_num > 0:
+        song_filename = "{:02d} - {}.{}".format(track_num, song['SNG_TITLE'], file_extension)
     else:
-        song_filename = "{} - {}.{}".format(song['ART_NAME'],
-                                            song['SNG_TITLE'],
-                                            file_extension)
+        song_filename = "{}.{}".format(song['SNG_TITLE'], file_extension)
     song_filename = clean_filename(song_filename)
 
     if search_type == TYPE_TRACK:
         absolute_filename = os.path.join(config["download_dirs"]["songs"], song_filename)
     elif search_type == TYPE_ALBUM:
-        album_name = "{} - {}".format(song['ART_NAME'], song['ALB_TITLE'])
-        album_name = clean_filename(album_name)
-        album_dir = os.path.join(config["download_dirs"]["albums"], album_name)
-        if not os.path.exists(album_dir):
-            os.mkdir(album_dir)
+        # Build nested path: Albums/<Artist>/<Album Title>
+        artist_dir_name = clean_filename(song.get('ART_NAME', 'Unknown Artist'))
+        album_dir_name = clean_filename(song.get('ALB_TITLE', 'Unknown Album'))
+        album_dir = os.path.join(config["download_dirs"]["albums"], artist_dir_name, album_dir_name)
+        os.makedirs(album_dir, exist_ok=True)
         absolute_filename = os.path.join(album_dir, song_filename)
     elif search_type == TYPE_PLAYLIST:
         assert type(playlist_name) is str


### PR DESCRIPTION
This cleans up downloaded album organization for easier browsing.

Albums now save to Albums/<Artist>/<Album Title>
Track files are named “NN - Title.ext” (no artist). Falls back to “Title.ext” if no track number
Minor Windows filename sanitization for quotes
Playlists and single-track downloads unchanged (except the cleaner filename)
Before

Albums/Kanye West - My Beautiful Dark Twisted Fantasy/01 - Kanye West - Dark Fantasy.mp3
After

Albums/Kanye West/My Beautiful Dark Twisted Fantasy/01 - Dark Fantasy.mp3